### PR TITLE
Setup publishing to npmjs

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -6,9 +6,6 @@ on: [pull_request]
 jobs:
   run-quality-checks:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,4 +1,4 @@
-name: Release Github Package
+name: Release Packages
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  NPM_TOKEN: ${{secrets.NPM_TOKEN}}
 
 jobs:
   test:
@@ -35,7 +35,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.10
-          registry-url: https://npm.pkg.github.com/
       - name: Setup Yarn
         run: corepack enable && corepack prepare yarn@4.7.0 --activate
       - run: yarn install --immutable
@@ -43,6 +42,6 @@ jobs:
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
-          publish: yarn npm publish
+          publish: yarn npm publish --access public
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -9,7 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -42,6 +42,7 @@ jobs:
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
-          publish: yarn npm publish --access public
+          publish: yarn npm publish --access public && cp .yarnrc_github_pkg.yml .yarnrc.yml && yarn npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,7 +2,7 @@ nodeLinker: node-modules
 
 npmScopes:
   multiverse-io:
-    npmAlwaysAuth: true
-    npmAuthToken: '${GITHUB_TOKEN}'
-    npmRegistryServer: 'https://npm.pkg.github.com'
-    npmPublishRegistry: 'https://npm.pkg.github.com'
+    npmRegistryServer: 'https://registry.npmjs.org'
+    npmPublishRegistry: 'https://registry.npmjs.org'
+    npmAlwaysAuth: false
+    npmAuthToken: "${NPM_TOKEN:-}"

--- a/.yarnrc_github_pkg.yml
+++ b/.yarnrc_github_pkg.yml
@@ -1,0 +1,8 @@
+nodeLinker: node-modules
+
+npmScopes:
+  multiverse-io:
+    npmAlwaysAuth: true
+    npmAuthToken: '${GITHUB_TOKEN}'
+    npmRegistryServer: 'https://npm.pkg.github.com'
+    npmPublishRegistry: 'https://npm.pkg.github.com'

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
   },
   "homepage": "https://github.com/Multiverse-io/cari#readme",
   "packageManager": "yarn@4.7.0",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "dependencies": {
     "@inquirer/prompts": "^7.4.0",
     "chalk": "^5.4.1",


### PR DESCRIPTION
Updates package so it is published to public npmjs repository instead of Github packages.

Initial publish has also been done manually and package is available here - https://www.npmjs.com/package/@multiverse-io/cari